### PR TITLE
chore: KST 설정, curl exit code 로깅

### DIFF
--- a/health_check.sh
+++ b/health_check.sh
@@ -6,7 +6,7 @@ DISCORD_WEBHOOK_URL=$DISCORD_WEBHOOK_URL
 check_site() {
     response=$(curl -s -o /dev/null -w "%{http_code}" -I -m 10 $SITE_URL)
     curl_exit_code=$?
-    current_time=$(TZ="Asia/Seoul", date "+%Y-%m-%d %H:%M:%S")
+    current_time=$(TZ="Asia/Seoul" date "+%Y-%m-%d %H:%M:%S")
     
     # 200 응답이 아니면 오류로 간주
     if [ "$response" != "200" ]; then

--- a/health_check.sh
+++ b/health_check.sh
@@ -5,12 +5,13 @@ DISCORD_WEBHOOK_URL=$DISCORD_WEBHOOK_URL
 
 check_site() {
     response=$(curl -s -o /dev/null -w "%{http_code}" -I -m 10 $SITE_URL)
-    current_time=$(date "+%Y-%m-%d %H:%M:%S")
+    curl_exit_code=$?
+    current_time=$(TZ="Asia/Seoul", date "+%Y-%m-%d %H:%M:%S")
     
     # 200 응답이 아니면 오류로 간주
     if [ "$response" != "200" ]; then
         if [ "$response" == "000" ]; then
-            message="🔴 **경고:** 사이트 접속 에러가 발생하고 있어요! ($current_time)"
+            message="🔴 **경고:** 사이트 접속 에러가 발생하고 있어요! (exit code: $curl_exit_code) ($current_time)"
         else
             message="🔴 **경고:** 사이트가 정상 응답을 못 하고 있어요! (status_code=$response) ($current_time)"
         fi


### PR DESCRIPTION
목적: 유지 보수(작은 코드 변경)
내용:
- KST 설정: github workflow 상의 UTC+0 시간을 KST(UTC+9)으로 로깅하도록 변경
- curl exit code: 응답코드가 000일 때 부가적인 에러 정보를 얻을 수 있도록 curl exit code 로깅 추가

주의사항: 실제로 동작하는지 확인하지 않음